### PR TITLE
Add support for https and github URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default, bucket `sps-build-deploy` and
 </dl>
 
 
-### Resove role or artifact dependencies
+### Resolve role or artifact dependencies
 
 Given a file `requirements.yml` in your current directory that looks like this:
 <pre>
@@ -65,3 +65,19 @@ can resolve the specified dependency by downloading the
 tarball to a temporary location and then pull each path `from` the source and 
 copy it `to` the specified destination, relative to the current working directory.
 
+### Example requirements.yml
+
+<pre>
+- url: https://github.com/geerlingguy/ansible-role-jenkins/archive/1.1.2.tar.gz
+  paths:
+  - from: ansible-role-jenkins-1.1.2/.
+    to: roles/jenkins
+- url: git@github.com:geerlingguy/ansible-role-java.git
+  paths:
+  - from: .
+    to: roles/geerlingguy.java
+- url: s3://sps-build-deploy/ansible/ansible-demo-tarball-0.0.0.tbz2
+  paths:
+  - from: inventory
+    to: ./
+</pre>

--- a/ansible-sdk.gemspec
+++ b/ansible-sdk.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'ansible-sdk'
-  spec.version       = '0.9.18'
+  spec.version       = '0.9.19'
   spec.authors       = ['Dan Farrell (dfarrell@spscommerce.com)']
   spec.email         = %w( cloudops@spscommerce.com )
   spec.summary       = 'Provides a consistent base for ansible development.'

--- a/lib/ansible-sdk-cli.rb
+++ b/lib/ansible-sdk-cli.rb
@@ -227,8 +227,12 @@ class AnsibleSDKCLI < Thor
         file.fsync
         asdk.unarchive( file.path, requirement['paths'] )
         file.unlink
-      elsif requirement['method'] == 'git' or requirement['url'] =~ /git@github\.com/
-        raise Exception, "git backends Unimplemented"
+      elsif requirement['url'] =~ /git@github\.com/
+        require 'git'
+        dir = Dir.mktmpdir
+        Git.clone(requirement['url'], dir)
+        asdk.gitpath( dir, requirement['paths'] )
+        FileUtils.remove_entry_secure dir
       else
         asdk.log.fatal(msg="Couldn't resolve dependency: #{requirement.inspect}")
         raise ArgumentError, msg

--- a/lib/ansible-sdk.rb
+++ b/lib/ansible-sdk.rb
@@ -86,6 +86,16 @@ Exit Status #{results[:exit_status]}"
     end
   end
 
+  def gitpath(archivepath,paths )
+    paths.each do |path|
+    FileUtils.mkdir_p path['to']
+      log.debug "#{File.join(archivepath, path['from'])}\t=>\t#{path['to']}"
+      FileUtils.rm_rf( File.join(archivepath, ".git"))
+      FileUtils.cp_r(File.join(archivepath, path['from']), path['to'])
+      gitignore_path(path['to'])
+    end
+  end
+
   def version path='./'
       versionpath = File.join path, 'VERSION' 
       begin


### PR DESCRIPTION
The https portion is pretty straight forward.

The github support actually removes the .git dir because 1) subsequent runs raise a EACCESS error and 2) we don't need to commit to the artifact in the future.

It is not clear to me about gem runtime deps, can someone comment on that? I will add another commit to this branch before merging.